### PR TITLE
Potential fix for code scanning alert no. 1384: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,6 @@
 name: Docker Image CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/edersonrnunes/frontierai/security/code-scanning/1384](https://github.com/edersonrnunes/frontierai/security/code-scanning/1384)

To fix this problem, explicitly set the minimal required permissions for the `GITHUB_TOKEN` at the root of the workflow by adding a `permissions` block at the top level of the YAML file, directly after the workflow `name`. Set `contents: read`, which is sufficient for jobs that only check out source code and perform read-only operations. No other permissions are necessary for the actions in this workflow. This change should be made near the very top of the `.github/workflows/docker-image.yml` file, between the `name` and `on` keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
